### PR TITLE
v2.0.5 - Enable cloudtrail-enabled Config Rule by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary
+      - image: trussworks/circleci-docker-primary:c3cdcb24c00afc1ba635f8f6efd215f55aaf2079
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:tf12-cb0bcbc3cb9b8b2465ec5721386771769ecaa9bb
+      - image: trussworks/circleci-docker-primary
     steps:
       - checkout
       - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,19 +12,17 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.19.0
+    rev: v0.21.0
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.19.0
+    rev: v1.22.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.21.0
+    rev: v1.22.2
     hooks:
       - id: golangci-lint
-        entry: golangci-lint run --verbose
-        verbose: true

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2017, TrussWorks, Inc.
+Copyright (c) 2020, TrussWorks, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ module "aws_config" {
 | check\_approved\_amis\_by\_tag | Enable approved-amis-by-tag rule | string | `"false"` | no |
 | check\_cloud\_trail\_encryption | Enable cloud-trail-encryption-enabled rule | string | `"false"` | no |
 | check\_cloud\_trail\_log\_file\_validation | Enable cloud-trail-log-file-validation-enabled rule | string | `"false"` | no |
-| check\_cloudtrail\_enabled | Enable cloudtrail-enabled rule | string | `"false"` | no |
+| check\_cloudtrail\_enabled | Enable cloudtrail-enabled rule | string | `"true"` | no |
 | check\_ec2\_encrypted\_volumes | Enable ec2-encrypted-volumes rule | string | `"true"` | no |
 | check\_ec2\_volume\_inuse\_check | Enable ec2-volume-inuse-check rule | string | `"true"` | no |
 | check\_eip\_attached | Enable eip-attached rule | string | `"false"` | no |

--- a/examples/required-tags/variables.tf
+++ b/examples/required-tags/variables.tf
@@ -1,11 +1,11 @@
 variable "config_logs_bucket" {
-  type = "string"
+  type = string
 }
 
 variable "region" {
-  type = "string"
+  type = string
 }
 
 variable "config_name" {
-  type = "string"
+  type = string
 }

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -1,11 +1,11 @@
 variable "config_name" {
-  type = "string"
+  type = string
 }
 
 variable "config_logs_bucket" {
-  type = "string"
+  type = string
 }
 
 variable "region" {
-  type = "string"
+  type = string
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/trussworks/terraform-aws-config
 go 1.13
 
 require (
-	github.com/gruntwork-io/terratest v0.23.0
+	github.com/gruntwork-io/terratest v0.23.3
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,6 @@ github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJr
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gruntwork-io/gruntwork-cli v0.5.1 h1:mVmVsFubUSLSCO8bGigI63HXzvzkC0uWXzm4dd9pXRg=
 github.com/gruntwork-io/gruntwork-cli v0.5.1/go.mod h1:IBX21bESC1/LGoV7jhXKUnTQTZgQ6dYRsoj/VqxUSZQ=
-github.com/gruntwork-io/terratest v0.23.0 h1:JmGeqO0r5zRLAV55T67NEmPZArz9lN3RKd0moAKhIT4=
-github.com/gruntwork-io/terratest v0.23.0/go.mod h1:+fVff0FQYuRzCF3LKpKF9ac+4w384LDcwLZt7O/KmEE=
 github.com/gruntwork-io/terratest v0.23.3 h1:zf3K7Z2g88yMgiZiJja5vAWsig8tRqG537Mp9S+qrFc=
 github.com/gruntwork-io/terratest v0.23.3/go.mod h1:+fVff0FQYuRzCF3LKpKF9ac+4w384LDcwLZt7O/KmEE=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/gruntwork-io/gruntwork-cli v0.5.1 h1:mVmVsFubUSLSCO8bGigI63HXzvzkC0uW
 github.com/gruntwork-io/gruntwork-cli v0.5.1/go.mod h1:IBX21bESC1/LGoV7jhXKUnTQTZgQ6dYRsoj/VqxUSZQ=
 github.com/gruntwork-io/terratest v0.23.0 h1:JmGeqO0r5zRLAV55T67NEmPZArz9lN3RKd0moAKhIT4=
 github.com/gruntwork-io/terratest v0.23.0/go.mod h1:+fVff0FQYuRzCF3LKpKF9ac+4w384LDcwLZt7O/KmEE=
+github.com/gruntwork-io/terratest v0.23.3 h1:zf3K7Z2g88yMgiZiJja5vAWsig8tRqG537Mp9S+qrFc=
+github.com/gruntwork-io/terratest v0.23.3/go.mod h1:+fVff0FQYuRzCF3LKpKF9ac+4w384LDcwLZt7O/KmEE=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=

--- a/variables.tf
+++ b/variables.tf
@@ -101,7 +101,7 @@ variable "check_multi_region_cloud_trail" {
 
 variable "check_cloudtrail_enabled" {
   description = "Enable cloudtrail-enabled rule"
-  default     = false
+  default     = true
 }
 
 variable "check_cloud_trail_encryption" {


### PR DESCRIPTION
- @dependabot-preview - Bump github.com/gruntwork-io/terratest from 0.23.0 to 0.23.3 … - 1e72aa5
- esacteksab - Base image is now default - 8916663
- esacteksab - It's 2020 liscence - e666626
- esacteksab - a little go mod tidy - 8b303d5
- esacteksab - Removing 0.11 syntax deprecation warnings - 44db484
- esacteksab and dynamike - Update .circleci/config.yml … - 0bfe879
- esacteksab - Merge pull request trussworks#29 from trussworks/barry-byebye-011 … - 15a265c
- dynamike - Have the cloudtrail-enabled check default to true. - fb1574f
- dynamike - Merge pull request trussworks#30 from trussworks/mk-default-cloudtrai… … - 040a9f1